### PR TITLE
Auth process correction

### DIFF
--- a/src/Restricted/Authchain/ChainAuthenticationProvider.php
+++ b/src/Restricted/Authchain/ChainAuthenticationProvider.php
@@ -91,4 +91,20 @@ class ChainAuthenticationProvider implements UserProviderInterface
     {
         return $this->delegator->resolver()->get('ip')->authenticate();
     }
+
+    /**
+    * Needed by Laravel 4.1.26 and above
+    */
+    public function retrieveByToken($identifier, $token)
+    {
+        return new \Exception('not implemented');
+    }
+
+    /**
+    * Needed by Laravel 4.1.26 and above
+    */
+    public function updateRememberToken(UserInterface $user, $token)
+    {
+        return new \Exception('not implemented');
+    } 
 }

--- a/src/Restricted/Authchain/ChainAuthenticationProvider.php
+++ b/src/Restricted/Authchain/ChainAuthenticationProvider.php
@@ -45,13 +45,14 @@ class ChainAuthenticationProvider implements UserProviderInterface
      */
     public function retrieveByCredentials(array $credentials)
     {
+
         $identifier = Loader::username();
-        $username = $credentials(Loader::username());
+        $username = $credentials[Loader::username()];
         if ($user = $this->delegator->native()->findBy($identifier, $username)) {
             return $user;
         }
 
-        return false;
+        return null;
     }
 
     /**
@@ -61,12 +62,16 @@ class ChainAuthenticationProvider implements UserProviderInterface
     {
         $plain = $credentials[Loader::password()];
 
-        if ($user = $this->delegator->provider($credentials)->authenticate()) {
-           return $user;
+        if(!$user){
+          return false;
+        }
+
+        if ($this->delegator->provider($credentials)->authenticate()) {
+           return true;
         }
 
         if (Hash::check($plain, $user->getAuthPassword())) {
-            return $user;
+            return true;
         }
 
         return false;

--- a/src/Restricted/Authchain/ChainAuthenticationProvider.php
+++ b/src/Restricted/Authchain/ChainAuthenticationProvider.php
@@ -66,12 +66,12 @@ class ChainAuthenticationProvider implements UserProviderInterface
           return false;
         }
 
-        if ($this->delegator->provider($credentials)->authenticate()) {
-           return true;
-        }
-
         if (Hash::check($plain, $user->getAuthPassword())) {
             return true;
+        }
+
+        if ($this->delegator->provider($credentials)->authenticate()) {
+           return true;
         }
 
         return false;

--- a/src/Restricted/Authchain/ChainAuthenticationProvider.php
+++ b/src/Restricted/Authchain/ChainAuthenticationProvider.php
@@ -45,7 +45,9 @@ class ChainAuthenticationProvider implements UserProviderInterface
      */
     public function retrieveByCredentials(array $credentials)
     {
-        if ($user = $this->delegator->provider($credentials)->authenticate() and $this->validateCredentials($user, $credentials)) {
+        $identifier = Loader::username();
+        $username = $credentials(Loader::username());
+        if ($user = $this->delegator->native()->findBy($identifier, $username)) {
             return $user;
         }
 
@@ -59,11 +61,15 @@ class ChainAuthenticationProvider implements UserProviderInterface
     {
         $plain = $credentials[Loader::password()];
 
-        if (!Hash::check($plain, $user->getAuthPassword())) {
-            return false;
+        if ($user = $this->delegator->provider($credentials)->authenticate()) {
+           return $user;
         }
 
-        return $user;
+        if (Hash::check($plain, $user->getAuthPassword())) {
+            return $user;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Restricted/Authchain/Provider/Domain/ImapProvider.php
+++ b/src/Restricted/Authchain/Provider/Domain/ImapProvider.php
@@ -37,7 +37,7 @@ class ImapProvider extends Provider implements ProviderInterface
 
         foreach ($this->config['hosts'] as $name => $address) {
             try {
-                $this->connection = \imap_open("{" . $address . "/novalidate-cert}", $this->username, $this->password, null, 1);
+                $this->connection = \imap_open("{" . $address . "/novalidate-cert}", $this->username, $this->password, null, 1, array("DISABLE_AUTHENTICATOR" => "GSSAPI"));
                 if ($this->connection) {
                     break;
                 }


### PR DESCRIPTION
Added retrieveByToken and updateRememberToken that are needed got Laravel 4.2.26 and above (copied from syphernl fork - https://github.com/syphernl/authchain/commit/685a10834185b835911f878165a6a7bc63111df8)

Disable GSSAPI should help with some error connection to Exchange IMAP

Reorganization of authentication process
-retrieveByCredentials returns $user if exists in database or null if not (If false is returned I got error from validateCredentials function)
-validateCredentials check first check against password in database and then over external resource (makes more sense to me to do it in this order)
-also its enough for validateCredentials to return true or false
